### PR TITLE
Load results on the fly

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -16,6 +16,8 @@ margin-bottom:0px;
 font-size:18px;
 margin-bottom:0px;
 margin-top:3px;
+padding-top: 8px;
+padding-bottom: 8px;
 }
 .infoCard .infoSubheadline {
   background: #f3f3f3;

--- a/competition.html
+++ b/competition.html
@@ -542,13 +542,63 @@
         <link rel="stylesheet" href="./assets/css/main.css"></noscript>
     <script
         type="text/javascript"> (function (w) { "use strict"; if (!w.loadCSS) { w.loadCSS = function () { } } var rp = loadCSS.relpreload = {}; rp.support = (function () { var ret; try { ret = w.document.createElement("link").relList.supports("preload") } catch (e) { ret = !1 } return function () { return ret } })(); rp.bindMediaToggle = function (link) { var finalMedia = link.media || "all"; function enableStylesheet() { link.media = finalMedia } if (link.addEventListener) { link.addEventListener("load", enableStylesheet) } else if (link.attachEvent) { link.attachEvent("onload", enableStylesheet) } setTimeout(function () { link.rel = "stylesheet"; link.media = "only x" }); setTimeout(enableStylesheet, 3000) }; rp.poly = function () { if (rp.support()) { return } var links = w.document.getElementsByTagName("link"); for (var i = 0; i < links.length; i++) { var link = links[i]; if (link.rel === "preload" && link.getAttribute("as") === "style" && !link.getAttribute("data-loadcss")) { link.setAttribute("data-loadcss", !0); rp.bindMediaToggle(link) } } }; if (!rp.support()) { rp.poly(); var run = w.setInterval(rp.poly, 500); if (w.addEventListener) { w.addEventListener("load", function () { rp.poly(); w.clearInterval(run) }) } else if (w.attachEvent) { w.attachEvent("onload", function () { rp.poly(); w.clearInterval(run) }) } } if (typeof exports !== "undefined") { exports.loadCSS = loadCSS } else { w.loadCSS = loadCSS } }(typeof global !== "undefined" ? global : this)) </script>
-    <script
-        type="text/javascript"> 
-        function buildDataTable() { 
-            const resultURL = 'https://competitions.codalab.org/competitions/24122/results/40018/data';
-            console.log(resultURL);
-        };
-         </script>
+        <script type="text/javascript">
+            function loadScript(src) {
+              return new Promise(function (resolve, reject) {
+                var s;
+                s = document.createElement('script');
+                s.src = src;
+                s.onload = resolve;
+                s.onerror = reject;
+                document.head.appendChild(s);
+              });
+            }
+            function buildDataTable() {
+              loadScript(
+                'https://cdn.jsdelivr.net/npm/jquery-csv@1.0.11/src/jquery.csv.min.js'
+              )
+                .then(() => {
+                  // TODO currently use a proxy to solve CORS problem
+                  const proxyUrl = 'https://cors-anywhere.herokuapp.com/';
+                  const resultURL =
+                    'https://competitions.codalab.org/competitions/24122/results/40018/data';
+                  return fetch(proxyUrl + resultURL);
+                })
+                .then((response) => response.text())
+                .then((csvText) => {
+                  const results = $.csv.toObjects(csvText);
+                  const tableRows = results.map(
+                    (e, idx) => `
+          <tr class="leaderboardline${idx % 2 === 0 ? '' : 'mask'}">
+          <td><p class="word-break2">${idx + 1}</p></td>
+          <td class="word-break">${e['User']}</td>
+          <td class="word-break"><b>${e['AUC']}</b></td>
+          <td class="word-break"><b>${e['MRR']}</b></td>
+          <td class="word-break"><b>${e['nDCG@5']}</b></td>
+          <td class="word-break"><b>${e['nDCG@10']}</b></td>
+          </tr>`
+                  );
+                  document.querySelector('.infoBody').innerHTML = `
+          <table class="table performanceTable">
+          <tr class="leaderboardhead">
+          <th>Rank</th>
+          <th>User</th>
+          <th>AUC</th>
+          <th>MRR</th>
+          <th>nDCG@5</th>
+          <th>nDCG@10</th>
+          </tr>
+          ${tableRows.join('')}
+          </table>
+          `;
+                })
+                .catch(() => {
+                  document.querySelector(
+                    '.infoBody'
+                  ).innerHTML = `Error while loading results. Click <a href="https://competitions.codalab.org/competitions/24122?secret_key=e075b839-d0cb-4c7b-b755-b34c5a666cba#results" target="_blank">here</a> to visit the original page.`;
+                });
+            }
+          </script>          
     <script type="text/javascript">
         function checkAllBox(obj) {
             var join = document.getElementById("join");
@@ -651,116 +701,7 @@ This challenge will provide a good testbed for participants to develop better ne
             <div class="col-md-7">
                 <div class="infoCard">
                     <div class="infoBody">
-                        <table class="table performanceTable">
-                            <tr class='leaderboardhead'>
-                                <th>
-                                    Rank
-                                </th>
-                                <th>
-                                    User
-                                </th>
-                                <th>
-                                    AUC
-                                </th>
-                                <th>
-                                    MRR
-                                </th>
-                                <th>
-                                    nDCG@5
-                                </th>
-                                <th>
-                                    nDCG@10
-                                </th>
-                            </tr>
-                            <tr class='leaderboardline'>
-                                <td>
-                                    <p class="word-break2">
-                                        1
-                                    </p><span class="date label label-default">Apr. 01, 2020</span>
-                                </td>
-                                <td class="word-break">
-                                    THU_NGN
-                                </td>
-                                <td class="word-break">
-                                    <b>0.6420</b>
-                                </td>
-                                <td class="word-break">
-                                    <b>0.1174</b>
-                                </td>
-                                <td class="word-break">
-                                    <b>0.3253</b>
-                                </td>
-                                <td class="word-break">
-                                    <b>0.3905</b>
-                                </td>
-                            </tr>
-                            <tr class='leaderboardlinemask'>
-                                <td>
-                                    <p class="word-break2">
-                                        2
-                                    </p><span class="date label label-default">Jul. 05, 2020</span>
-                                </td>
-                                <td class="word-break">
-                                    Test team creation2
-                                </td>
-                                <td class="word-break">
-                                    <b>0.6156</b>
-                                </td>
-                                <td class="word-break">
-                                    <b>0.2824</b>
-                                </td>
-                                <td class="word-break">
-                                    <b>0.3076</b>
-                                </td>
-                                <td class="word-break">
-                                    <b>0.3709</b>
-                                </td>
-                            </tr>
-                            <tr class='leaderboardline'>
-                                <td>
-                                    <p class="word-break2">
-                                        3
-                                    </p><span class="date label label-default">Jul. 05, 2020</span>
-                                </td>
-                                <td class="word-break">
-                                    Test
-                                </td>
-                                <td class="word-break">
-                                    <b>0.6156</b>
-                                </td>
-                                <td class="word-break">
-                                    <b>0.2824</b>
-                                </td>
-                                <td class="word-break">
-                                    <b>0.3076</b>
-                                </td>
-                                <td class="word-break">
-                                    <b>0.3709</b>
-                                </td>
-                            </tr>
-                            <tr class='leaderboardlinemask'>
-                                <td>
-                                    <p class="word-break2">
-                                        4
-                                    </p><span class="date label label-default">Jun. 15, 2020</span>
-                                </td>
-                                <td class="word-break">
-                                    Anonymous
-                                </td>
-                                <td class="word-break">
-                                    <b>0.4991</b>
-                                </td>
-                                <td class="word-break">
-                                    <b>0.2183</b>
-                                </td>
-                                <td class="word-break">
-                                    <b>0.2230</b>
-                                </td>
-                                <td class="word-break">
-                                    <b>0.2857</b>
-                                </td>
-                            </tr>
-                        </table>
+                        Loading data...
                     </div>
                 </div>
             </div><br>

--- a/competition.html
+++ b/competition.html
@@ -16,7 +16,7 @@
     <meta property="og:site_name" content="MIND" />
     <meta property="og:type" content="article" />
 
-    <link rel="icon" type="image/png" sizes="32x32" href="https://msnews.github.io/assets/img/icons/M.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="./assets/img/icons/M.png">
     <meta name="apple-mobile-web-app-title" content="MIND">
     <meta name="application-name" content="MIND">
     <meta name="theme-color" content="#ffffff">
@@ -537,13 +537,18 @@
             }
         }
     </style>
-    <link rel="preload" href="https://msnews.github.io/assets/css/main.css" as="style" onload="this.rel='stylesheet'">
+    <link rel="preload" href="./assets/css/main.css" as="style" onload="this.rel='stylesheet'">
     <noscript>
-        <link rel="stylesheet" href="https://msnews.github.io/assets/css/main.css"></noscript>
+        <link rel="stylesheet" href="./assets/css/main.css"></noscript>
     <script
         type="text/javascript"> (function (w) { "use strict"; if (!w.loadCSS) { w.loadCSS = function () { } } var rp = loadCSS.relpreload = {}; rp.support = (function () { var ret; try { ret = w.document.createElement("link").relList.supports("preload") } catch (e) { ret = !1 } return function () { return ret } })(); rp.bindMediaToggle = function (link) { var finalMedia = link.media || "all"; function enableStylesheet() { link.media = finalMedia } if (link.addEventListener) { link.addEventListener("load", enableStylesheet) } else if (link.attachEvent) { link.attachEvent("onload", enableStylesheet) } setTimeout(function () { link.rel = "stylesheet"; link.media = "only x" }); setTimeout(enableStylesheet, 3000) }; rp.poly = function () { if (rp.support()) { return } var links = w.document.getElementsByTagName("link"); for (var i = 0; i < links.length; i++) { var link = links[i]; if (link.rel === "preload" && link.getAttribute("as") === "style" && !link.getAttribute("data-loadcss")) { link.setAttribute("data-loadcss", !0); rp.bindMediaToggle(link) } } }; if (!rp.support()) { rp.poly(); var run = w.setInterval(rp.poly, 500); if (w.addEventListener) { w.addEventListener("load", function () { rp.poly(); w.clearInterval(run) }) } else if (w.attachEvent) { w.attachEvent("onload", function () { rp.poly(); w.clearInterval(run) }) } } if (typeof exports !== "undefined") { exports.loadCSS = loadCSS } else { w.loadCSS = loadCSS } }(typeof global !== "undefined" ? global : this)) </script>
     <script
-        type="text/javascript"> function getJson(url) { return JSON.parse($.ajax({ type: 'GET', url: url, dataType: 'json', global: false, async: false, success: function (data) { return data; } }).responseText); } function buildDataTable() { var leaderboard = []; leaderboard.push(getJson("https://yjw.wh98.me:8080")[0]); var tr; $("#leaderboardtable").empty(); var columnSet = []; var headerTr$ = $('<tr/>'); var headers = leaderboard[0].headers; headerTr$.append($('<th/>').html("participant")); for (var j = 0; j < headers.length; j++) { headerTr$.append($('<th/>').html(headers[j].label)); } $("#leaderboardtable").append(headerTr$); for (var i = 0; i < leaderboard[0].scores.length; i++) { tr = $('<tr/>'); tr.append("<td>" + leaderboard[0].scores[i][1].username + "</td>"); values = leaderboard[0].scores[i][1].values; for (var j = 0; j < values.length; j++) { tr.append("<td>" + values[j].val + "</td>"); } $('#leaderboardtable').append(tr); } console.log(leaderboard) } </script>
+        type="text/javascript"> 
+        function buildDataTable() { 
+            const resultURL = 'https://competitions.codalab.org/competitions/24122/results/40018/data';
+            console.log(resultURL);
+        };
+         </script>
     <script type="text/javascript">
         function checkAllBox(obj) {
             var join = document.getElementById("join");
@@ -555,11 +560,9 @@
             }
         }
     </script>
-    <!-- <script type="text/javascript"> 
+    <script type="text/javascript"> 
         window.onload = function (){ 
             buildDataTable();
-            var term_agree = document.getElementById("TermAgree");
-            checkAllBox(term_agree);
         } </script> -->
 </head>
 
@@ -578,7 +581,7 @@
                             </g>
                         </svg> -->
                         <img style="max-width:200%; width:90px;" alt="backgound image"
-                            src="https://msnews.github.io/assets/img/icons/logo.png">
+                            src="./assets/img/icons/logo.png">
                     </div>
                 </a>
                 <nav class="header__links">
@@ -596,7 +599,7 @@
             </div>
         </div>
     </header>
-    <div class="hero lazyload" data-bg="https://msnews.github.io/assets/img/posts/sleek.jpg">
+    <div class="hero lazyload" data-bg="./assets/img/posts/sleek.jpg">
         <div class="hero__wrap">
             <div class="hero__categories"></div>
             <h1 class="hero__title2">MIND News Recommendation Competition</h1>
@@ -627,7 +630,7 @@
   </p>
   <p>
 To promote the research and practice on news recommendation, 
-we hold a <strong> MIND News Recommendation Competition </strong>based on the <a href="https://msnews.github.io/index.html">MIND dataset</a>, 
+we hold a <strong> MIND News Recommendation Competition </strong>based on the <a href="./index.html">MIND dataset</a>, 
 which is a large-scale English dataset for news recommendation. 
 This challenge will provide a good testbed for participants to develop better news recommender systems to improve the future reading experience of millions of users.
                      </p>
@@ -777,7 +780,7 @@ This challenge will provide a good testbed for participants to develop better ne
             <span> ©2020 Microsoft </span>
         </div>
     </footer>
-    <script async src="https://msnews.github.io/assets/js/bundle.js"></script>
+    <script async src="./assets/js/bundle.js"></script>
 
 </body>
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta property="og:site_name" content="MIND" />
     <meta property="og:type" content="article" />
 
-    <link rel="icon" type="image/png" sizes="32x32" href="https://msnews.github.io/assets/img/icons/M.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="./assets/img/icons/M.png">
     <meta name="apple-mobile-web-app-title" content="MIND">
     <meta name="application-name" content="MIND">
     <meta name="theme-color" content="#ffffff">
@@ -536,13 +536,11 @@
             }
         }
     </style>
-    <link rel="preload" href="https://msnews.github.io/assets/css/main.css" as="style" onload="this.rel='stylesheet'">
+    <link rel="preload" href="./assets/css/main.css" as="style" onload="this.rel='stylesheet'">
     <noscript>
-        <link rel="stylesheet" href="https://msnews.github.io/assets/css/main.css"></noscript>
+        <link rel="stylesheet" href="./assets/css/main.css"></noscript>
     <script
         type="text/javascript"> (function (w) { "use strict"; if (!w.loadCSS) { w.loadCSS = function () { } } var rp = loadCSS.relpreload = {}; rp.support = (function () { var ret; try { ret = w.document.createElement("link").relList.supports("preload") } catch (e) { ret = !1 } return function () { return ret } })(); rp.bindMediaToggle = function (link) { var finalMedia = link.media || "all"; function enableStylesheet() { link.media = finalMedia } if (link.addEventListener) { link.addEventListener("load", enableStylesheet) } else if (link.attachEvent) { link.attachEvent("onload", enableStylesheet) } setTimeout(function () { link.rel = "stylesheet"; link.media = "only x" }); setTimeout(enableStylesheet, 3000) }; rp.poly = function () { if (rp.support()) { return } var links = w.document.getElementsByTagName("link"); for (var i = 0; i < links.length; i++) { var link = links[i]; if (link.rel === "preload" && link.getAttribute("as") === "style" && !link.getAttribute("data-loadcss")) { link.setAttribute("data-loadcss", !0); rp.bindMediaToggle(link) } } }; if (!rp.support()) { rp.poly(); var run = w.setInterval(rp.poly, 500); if (w.addEventListener) { w.addEventListener("load", function () { rp.poly(); w.clearInterval(run) }) } else if (w.attachEvent) { w.attachEvent("onload", function () { rp.poly(); w.clearInterval(run) }) } } if (typeof exports !== "undefined") { exports.loadCSS = loadCSS } else { w.loadCSS = loadCSS } }(typeof global !== "undefined" ? global : this)) </script>
-    <script
-        type="text/javascript"> function getJson(url) { return JSON.parse($.ajax({ type: 'GET', url: url, dataType: 'json', global: false, async: false, success: function (data) { return data; } }).responseText); } function buildDataTable() { var leaderboard = []; leaderboard.push(getJson("https://yjw.wh98.me:8080")[0]); var tr; $("#leaderboardtable").empty(); var columnSet = []; var headerTr$ = $('<tr/>'); var headers = leaderboard[0].headers; headerTr$.append($('<th/>').html("participant")); for (var j = 0; j < headers.length; j++) { headerTr$.append($('<th/>').html(headers[j].label)); } $("#leaderboardtable").append(headerTr$); for (var i = 0; i < leaderboard[0].scores.length; i++) { tr = $('<tr/>'); tr.append("<td>" + leaderboard[0].scores[i][1].username + "</td>"); values = leaderboard[0].scores[i][1].values; for (var j = 0; j < values.length; j++) { tr.append("<td>" + values[j].val + "</td>"); } $('#leaderboardtable').append(tr); } console.log(leaderboard) } </script>
     <script type="text/javascript">
         function checkAllBox(obj) {
             var train_set = document.getElementById("train-set");
@@ -563,12 +561,6 @@
             }
         }
     </script>
-    <!-- <script type="text/javascript"> 
-        window.onload = function (){ 
-            buildDataTable();
-            var term_agree = document.getElementById("TermAgree");
-            checkAllBox(term_agree);
-        } </script> -->
 </head>
 
 <body class="site">
@@ -586,7 +578,7 @@
                             </g>
                         </svg> -->
                         <img style="max-width:200%; width:90px;" alt="backgound image"
-                            src="https://msnews.github.io/assets/img/icons/logo.png">
+                            src="./assets/img/icons/logo.png">
                     </div>
                 </a>
                 <nav class="header__links">
@@ -605,7 +597,7 @@
             </div>
         </div>
     </header>
-    <div class="hero lazyload" data-bg="https://msnews.github.io/assets/img/posts/sleek.jpg">
+    <div class="hero lazyload" data-bg="./assets/img/posts/sleek.jpg">
         <div class="hero__wrap">
             <div class="hero__categories"></div>
             <h1 class="hero__title">MIND: MIcrosoft News Dataset</h1>
@@ -670,7 +662,7 @@
                 For more details about the data formats, please refer to this document:
             </p>
             <div class="button-container">
-                <button class="button button-pill button-border" onclick="location.href='https://github.com/msnews/msnews.github.io/blob/master/assets/doc/introduction.md';"><strong>Dataset Description</strong></button>
+                <button class="button button-pill button-border" onclick="location.href='./assets/doc/introduction.md';"><strong>Dataset Description</strong></button>
             </div><br>
             <p>
                 In addition, to help the researchers get familiar with our data and run quick experiments, we release a small version of the MIND dataset by randomly sampling 50,000 users and their behavior logs from the MIND dataset. We name this dataset <strong>MIND-small</strong>. The training and validation sets of MIND-small can be downloaded at:
@@ -698,7 +690,7 @@
             <span> ©2020 Microsoft </span>
         </div>
     </footer>
-    <script async src="https://msnews.github.io/assets/js/bundle.js"></script>
+    <script async src="./assets/js/bundle.js"></script>
 
 </body>
 


### PR DESCRIPTION
**Update**
- Load results on the fly
- Use relative URLs

**Screenshot**
Loading
![image](https://user-images.githubusercontent.com/36265606/86880779-c6b32e80-c11f-11ea-99eb-c30fb5495f0b.png)

Loaded
![image](https://user-images.githubusercontent.com/36265606/86880792-cdda3c80-c11f-11ea-99f6-081ddc5266a2.png)

Error
![image](https://user-images.githubusercontent.com/36265606/86880813-d6327780-c11f-11ea-85ee-93138c1478fb.png)


**Question**
- Currently in order to handle CORS related problem, I use a dirty solution: a proxy (see <https://github.com/yusanshi/msnews.github.io/blob/master/competition.html#L561-L565>). Refer to [codaLab docs](https://github.com/codalab/codalab-competitions/wiki/Storage#setting-cors), it seems that CORS can be configurated to allow requests from <https://msnews.github.io/>. It may help but I'm not sure.
- Shoud I minify the code?
- Date info is not handled because it is missed in <https://competitions.codalab.org/competitions/24122/results/40018/data>. <https://competitions.codalab.org/competitions/24122/results/40018> has such information but it may be too dirty to parse a html text file. I need help.

